### PR TITLE
serialization

### DIFF
--- a/alpsqutip/alpsmodels.py
+++ b/alpsqutip/alpsmodels.py
@@ -411,6 +411,25 @@ class ModelDescriptor:
     def __repr__(self):
         return repr(self.__dict__)
 
+    def __eq__(self, other):
+        if self.name != other.name:
+
+            return False
+        if self.site_basis != other.site_basis:
+
+            return False
+        if self.parms != other.parms:
+
+            return False
+        if self.bond_ops != other.bond_ops:
+
+            return False
+        if self.global_ops != other.global_ops:
+
+            return False
+
+        return True
+
 
 def qutip_model_from_dims(dims, local_ops=None, global_ops=None, model_name="qutip"):
     """

--- a/alpsqutip/alpsmodels.py
+++ b/alpsqutip/alpsmodels.py
@@ -412,8 +412,10 @@ class ModelDescriptor:
         return repr(self.__dict__)
 
     def __eq__(self, other):
+        # To be the same, two ``ModelDescriptor``
+        # objects should share their `name`, `parms`,
+        # `site_basis`, `bond_ops` and `global_ops`
         if self.name != other.name:
-
             return False
         if self.site_basis != other.site_basis:
 

--- a/alpsqutip/geometry.py
+++ b/alpsqutip/geometry.py
@@ -423,10 +423,7 @@ class GraphDescriptor:
 
     def __getstate__(self):
         # Copy the object's state and exclude _subsystems_cache
-        subgraphs_tmp = self.subgraphs
-        self.subgraphs = {}
-        state = self.__dict__.copy()
-        self.subgraphs = subgraphs_tmp
+        state = {key: {} if key == "subgraphs" else val for key, val in self.__dict__.items()}
         return state
 
     def __setstate__(self, state):

--- a/alpsqutip/geometry.py
+++ b/alpsqutip/geometry.py
@@ -421,6 +421,31 @@ class GraphDescriptor:
         self.complete_coordiantes()
         self.subgraphs = {}
 
+    def __getstate__(self):
+        # Copy the object's state and exclude _subsystems_cache
+        subgraphs_tmp = self.subgraphs
+        self.subgraphs = {}
+        state = self.__dict__.copy()
+        self.subgraphs = subgraphs_tmp
+        return state
+
+    def __setstate__(self, state):
+        self.__dict__.update(state)
+
+    def __eq__(self, other):
+        assert isinstance(other, GraphDescriptor)
+        if self.name != other.name:
+            return False
+        if self.nodes != other.nodes:
+            return False
+        if self.edges != other.edges:
+            return False
+        if self.loops != other.loops:
+            return False
+        if self.parms != other.parms:
+            return False
+        return True
+
     def complete_coordiantes(self):
         """Add coordinates to nodes without specified coordinates"""
         nodes = self.nodes

--- a/alpsqutip/geometry.py
+++ b/alpsqutip/geometry.py
@@ -423,13 +423,18 @@ class GraphDescriptor:
 
     def __getstate__(self):
         # Copy the object's state and exclude _subsystems_cache
-        state = {key: {} if key == "subgraphs" else val for key, val in self.__dict__.items()}
+        state = {
+            key: {} if key == "subgraphs" else val for key, val in self.__dict__.items()
+        }
         return state
 
     def __setstate__(self, state):
         self.__dict__.update(state)
 
     def __eq__(self, other):
+        # To be the same, two GraphDescriptors
+        # should have the same `name`, `nodes`,
+        # `loops`, `edges` and `parms`.
         assert isinstance(other, GraphDescriptor)
         if self.name != other.name:
             return False

--- a/alpsqutip/model.py
+++ b/alpsqutip/model.py
@@ -73,6 +73,9 @@ class SystemDescriptor:
         self._load_global_ops()
 
     def __eq__(self, other):
+        # To be the equal, two SystemDescriptors
+        # should have the same values in the
+        # `spec` attribute:
         assert isinstance(other, SystemDescriptor)
         for key in self.spec:
             if other.spec[key] != self.spec[key]:

--- a/alpsqutip/model.py
+++ b/alpsqutip/model.py
@@ -97,13 +97,10 @@ class SystemDescriptor:
         if hasattr(self, "_serialized"):
             return self._serialized
 
-        subsystems_cache_tmp = self._subsystems_cache
-        operators_dict_tmp = self.operators
-        self._subsystems_cache = {}
-        self.operators = {}
-        state = self.__dict__.copy()
-        self._subsystems_cache = subsystems_cache_tmp
-        self.operators = operators_dict_tmp
+        state = {
+            key: {} if key in ("_subsystems_cache", "operators") else val
+            for key, val in self.__dict__.items()
+        }
         self._serialized = pickle.dumps(state)
         return self._serialized
 

--- a/alpsqutip/model.py
+++ b/alpsqutip/model.py
@@ -3,6 +3,7 @@ Define SystemDescriptors and different kind of operators
 """
 
 import logging
+import pickle
 import re
 from typing import Optional, Tuple
 
@@ -71,6 +72,13 @@ class SystemDescriptor:
         self._load_site_operators()
         self._load_global_ops()
 
+    def __eq__(self, other):
+        assert isinstance(other, SystemDescriptor)
+        for key in self.spec:
+            if other.spec[key] != self.spec[key]:
+                return False
+        return True
+
     def __repr__(self):
         result = (
             "graph:"
@@ -83,6 +91,25 @@ class SystemDescriptor:
             + repr(self.dimensions)
         )
         return result
+
+    def __getstate__(self):
+        # Copy the object's state and exclude _subsystems_cache and operators
+        if hasattr(self, "_serialized"):
+            return self._serialized
+
+        subsystems_cache_tmp = self._subsystems_cache
+        operators_dict_tmp = self.operators
+        self._subsystems_cache = {}
+        self.operators = {}
+        state = self.__dict__.copy()
+        self._subsystems_cache = subsystems_cache_tmp
+        self.operators = operators_dict_tmp
+        self._serialized = pickle.dumps(state)
+        return self._serialized
+
+    def __setstate__(self, state):
+        state_dict = pickle.loads(state)
+        self.__dict__.update(state_dict)
 
     def subsystem(self, sites: frozenset):
         """

--- a/alpsqutip/operators/states/basic.py
+++ b/alpsqutip/operators/states/basic.py
@@ -3,6 +3,7 @@ Density operator classes.
 """
 
 import logging
+import pickle
 from numbers import Number
 from typing import Iterable, Optional, Tuple, Union, cast
 
@@ -119,6 +120,17 @@ class DensityOperatorMixin:
                 tuple((operand, self)), self.system.union(operand.system)
             )
         return operand - (-self)
+
+    def __getstate__(self):
+        if hasattr(self, "_serialized"):
+            return self._serialized
+        state = self.__dict__.copy()
+        self._serialized = pickle.dumps(state)
+        return self._serialized
+
+    def __setstate__(self, state):
+        state_dict = pickle.loads(state)
+        self.__dict__.update(state_dict)
 
     def dag(self) -> Operator:
         return cast(Operator, self)

--- a/alpsqutip/operators/states/qutip.py
+++ b/alpsqutip/operators/states/qutip.py
@@ -232,7 +232,7 @@ class QutipDensityOperator(DensityOperatorMixin, QutipOperator):
     def to_qutip(self, block: Optional[Tuple[str]] = None):
         self.normalize()
         # set the prefactor temporarily to 1, because it should
-        # not be taken into account in the convertion of a state.
+        # not be taken into account in the conversion of a state.
         prefactor = self.prefactor
         self.prefactor = 1
         qutip_op = super().to_qutip(block)

--- a/test/test_serialize.py
+++ b/test/test_serialize.py
@@ -1,0 +1,98 @@
+import pickle
+
+import pytest
+
+from alpsqutip.geometry import GraphDescriptor
+from alpsqutip.model import SystemDescriptor
+from alpsqutip.operators import Operator
+
+from .helper import (
+    FULL_TEST_CASES,
+    OPERATOR_TYPE_CASES,
+    SYSTEM,
+    TEST_CASES_STATES,
+    check_operator_equality,
+)
+
+
+def test_serialize_graph():
+    graph = SYSTEM.spec["graph"]
+    a = pickle.dumps(graph)
+    reconstructed_graph = pickle.loads(a)
+    assert isinstance(reconstructed_graph, GraphDescriptor)
+    assert graph == reconstructed_graph
+
+
+def test_serialize_system():
+    a = pickle.dumps(SYSTEM)
+    reconstructed_system = pickle.loads(a)
+    assert isinstance(reconstructed_system, SystemDescriptor)
+    assert SYSTEM == reconstructed_system
+
+
+@pytest.mark.parametrize(["name", "operator"], list(FULL_TEST_CASES.items()))
+def test_serialize_operator(name, operator):
+    a = pickle.dumps(operator)
+    reconstructed_operator = pickle.loads(a)
+    assert isinstance(reconstructed_operator, Operator)
+    assert check_operator_equality(operator, reconstructed_operator, tolerance=1e-8)
+
+
+def worker_add_a_number(q):
+    op1, number = q.get()
+    q.put(op1 + number)
+
+
+@pytest.mark.parametrize(["name", "operator"], list(FULL_TEST_CASES.items()))
+def test_process_add_number(name, operator):
+    from multiprocessing import Process, Queue
+
+    my_queue = Queue()
+    p = Process(target=worker_add_a_number, args=(my_queue,))
+    p.start()
+    my_queue.put(
+        (
+            operator,
+            1.0,
+        )
+    )
+    p.join()
+    result_worker = my_queue.get()
+    result_mine = operator + 1.0
+    assert check_operator_equality(result_worker, result_mine, tolerance=1e-8)
+
+
+def worker_expect(q):
+    state, obs = q.get()
+    q.put(state.expect(obs))
+
+
+@pytest.mark.parametrize(
+    ["state_name", "operator_name"],
+    [
+        (
+            state_name,
+            operator_name,
+        )
+        for state_name in TEST_CASES_STATES
+        for operator_name in OPERATOR_TYPE_CASES
+    ],
+)
+def test_process_expect(state_name, operator_name):
+    from multiprocessing import Process, Queue
+
+    state = TEST_CASES_STATES[state_name]
+    operator = OPERATOR_TYPE_CASES[operator_name]
+    my_queue = Queue()
+    p = Process(target=worker_expect, args=(my_queue,))
+    p.start()
+    my_queue.put(
+        (
+            state,
+            operator,
+        )
+    )
+    p.join()
+    result_worker = my_queue.get()
+    result_mine = state.expect(operator)
+    assert abs(result_worker - result_mine) < 1e-9


### PR DESCRIPTION
These changes are needed to reduce the cost of parallelizing using multiprocess scheme. Since each Operator charges with a reference to the system object, each time operators are sent to a process, the System object is re-serialized. With this changes, the serialization is properly cached, avoiding to store cached objects (like subsystems).