### PR TITLE
Benchmark expect

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,10 +73,10 @@ docs-clean:
 
 
 benchmark:
-
-	BENCHMARKS=1 CHAIN_SIZE=20 pytest --benchmark-enable --benchmark-save="gram_$(BENCHMARK_FILE)" --benchmark-columns=min test/scalar_product/test_gram.py
-	BENCHMARKS=1 CHAIN_SIZE=20 pytest --benchmark-enable --benchmark-save="commutators_$(BENCHMARK_FILE)" --benchmark-columns=min test/basic_operators/test_operator_functions_benchmarks.py
-	BENCHMARKS=1 CHAIN_SIZE=20 pytest -x --benchmark-enable --benchmark-save="projections_$(BENCHMARK_FILE)" --benchmark-columns=min test/states/test_projections_benchmark.py
+	BENCHMARKS=1 ALPSQUTIP_ALLTESTS=1 CHAIN_SIZE=20 pytest -x --benchmark-enable --benchmark-save="expect_$(BENCHMARK_FILE)" --benchmark-columns=min test/states/test_expect_benchmark.py
+	BENCHMARKS=1 ALPSQUTIP_ALLTESTS=1 CHAIN_SIZE=20 pytest --benchmark-enable --benchmark-save="gram_$(BENCHMARK_FILE)" --benchmark-columns=min test/scalar_product/test_gram.py
+	BENCHMARKS=1 ALPSQUTIP_ALLTESTS=1 CHAIN_SIZE=20 pytest --benchmark-enable --benchmark-save="commutators_$(BENCHMARK_FILE)" --benchmark-columns=min test/basic_operators/test_operator_functions_benchmarks.py
+	BENCHMARKS=1 ALPSQUTIP_ALLTESTS=1 CHAIN_SIZE=20 pytest -x --benchmark-enable --benchmark-save="projections_$(BENCHMARK_FILE)" --benchmark-columns=min test/states/test_projections_benchmark.py
 
 
 benchmark-clean:

--- a/alpsqutip/operators/states/utils.py
+++ b/alpsqutip/operators/states/utils.py
@@ -3,7 +3,7 @@ Utility functions for alpsqutip.operators.states
 
 """
 
-from typing import Dict, Iterable, List, Union, cast
+from typing import Any, Dict, Iterable, List, Optional, Union, cast
 
 import numpy as np
 from qutip import Qobj, tensor as qutip_tensor
@@ -25,6 +25,19 @@ from alpsqutip.operators.states.qutip import QutipDensityOperator
 from alpsqutip.qutip_tools.tools import (
     safe_exp_and_normalize as safe_exp_and_normalize_qobj,
 )
+
+
+def compute_expectation_values(
+    obs: Operator | Iterable[Operator] | Dict[Any, Operator],
+    state: Optional[DensityOperatorMixin],
+):
+    """
+    Compute the expectation value of an operator or operators in an iterable object,
+    relative to the state `state`.
+    """
+    if state is None:
+        state = ProductDensityOperator({}, 1, obs.system)
+    return state.expect(obs)
 
 
 def collect_blocks_for_expect(obs_objs: Union[Operator, Iterable]) -> List[frozenset]:

--- a/test/states/test_expect_benchmark.py
+++ b/test/states/test_expect_benchmark.py
@@ -33,19 +33,24 @@ if os.environ.get("BENCHMARKS", 0):
         + 0.3 * TEST_CASES_STATES["first full polarized"]
         + 0.1 * TEST_CASES_STATES["gibbs_sz_bar"]
     )
+    BENCHMARK_EXPECTATION_CASES = (
+        [
+            (
+                name_rho,
+                name_obs,
+            )
+            for name_rho in TEST_CASES_STATES
+            for name_obs in OBSERVABLE_CASES
+        ],
+    )
+else:
+    BENCHMARK_EXPECTATION_CASES = []
 
 
-@pytest.mark.parametrize(
-    ["name_rho", "name_obs"],
-    [
-        (
-            name_rho,
-            name_obs,
-        )
-        for name_rho in TEST_CASES_STATES
-        for name_obs in OBSERVABLE_CASES
-    ],
+@pytest.mark.skipif(
+    not os.environ.get("BENCHMARKS", 0), reason="run only in benchmarks"
 )
+@pytest.mark.parametrize(["name_rho", "name_obs"], BENCHMARK_EXPECTATION_CASES)
 def test_benchmark_expect(benchmark, name_rho, name_obs):
 
     rho = TEST_CASES_STATES[name_rho]

--- a/test/states/test_expect_benchmark.py
+++ b/test/states/test_expect_benchmark.py
@@ -1,0 +1,67 @@
+"""
+Basic unit test for states.
+"""
+
+import os
+from test.helper import (
+    HAMILTONIAN,
+    OBSERVABLE_CASES,
+    SX_TOTAL,
+    SY_TOTAL,
+    SZ_TOTAL,
+    TEST_CASES_STATES,
+)
+
+import pytest
+
+from alpsqutip.operators.states.gibbs import GibbsDensityOperator
+from alpsqutip.operators.states.utils import compute_expectation_values
+
+# from alpsqutip.settings import VERBOSITY_LEVEL
+
+if os.environ.get("BENCHMARKS", 0):
+    OBSERVABLE_CASES["sx_total^2"] = SX_TOTAL * SX_TOTAL
+    OBSERVABLE_CASES["sz_total^2"] = SZ_TOTAL * SZ_TOTAL
+    OBSERVABLE_CASES["HAMILTONIAN^2"] = HAMILTONIAN * HAMILTONIAN
+    TOTAL_SPIN_COMPONENTS = [SX_TOTAL, SY_TOTAL, SZ_TOTAL]
+    OBSERVABLE_CASES["total components of the spin"] = TOTAL_SPIN_COMPONENTS
+    OBSERVABLE_CASES["global quadratic list"] = TOTAL_SPIN_COMPONENTS + [
+        x * x for x in TOTAL_SPIN_COMPONENTS
+    ]
+    TEST_CASES_STATES["mixture"] = (
+        0.6 * TEST_CASES_STATES["x semipolarized"]
+        + 0.3 * TEST_CASES_STATES["first full polarized"]
+        + 0.1 * TEST_CASES_STATES["gibbs_sz_bar"]
+    )
+
+
+@pytest.mark.parametrize(
+    ["name_rho", "name_obs"],
+    [
+        (
+            name_rho,
+            name_obs,
+        )
+        for name_rho in TEST_CASES_STATES
+        for name_obs in OBSERVABLE_CASES
+    ],
+)
+def test_benchmark_expect(benchmark, name_rho, name_obs):
+
+    rho = TEST_CASES_STATES[name_rho]
+    obs = OBSERVABLE_CASES[name_obs]
+    print(type(rho), type(obs))
+    if isinstance(rho, (GibbsDensityOperator,)) and len(rho.system.sites) > 8:
+        return
+
+    if rho is None:
+
+        def impl():
+            return compute_expectation_values(obs, rho)
+
+    else:
+
+        def impl():
+            return rho.expect(obs)
+
+    benchmark.pedantic(impl, rounds=3, iterations=1)


### PR DESCRIPTION
Now, benchmarks are also measured for `DensityOperatorMixin.expect` and their descendent classes. 