### PR TITLE
Handle QutipOperator with scalars

### DIFF
--- a/alpsqutip/operators/qutip.py
+++ b/alpsqutip/operators/qutip.py
@@ -8,7 +8,7 @@ from functools import reduce
 from typing import Dict, List, Optional, Tuple, Union
 
 from numpy import imag, log as np_log
-from qutip import Qobj, tensor  # type: ignore[import-untyped]
+from qutip import Qobj, qeye, tensor  # type: ignore[import-untyped]
 
 from alpsqutip.alpsmodels import qutip_model_from_dims
 from alpsqutip.geometry import GraphDescriptor
@@ -50,15 +50,20 @@ class QutipOperator(Operator):
 
     def __init__(
         self,
-        qoperator: Qobj,
+        qoperator,
         system: Optional[SystemDescriptor] = None,
         names: Optional[Dict[str, int]] = None,
         prefactor=1,
     ):
-        assert isinstance(
-            qoperator, Qobj
-        ), f"qoperator should be a Qutip Operator. Was {type(qoperator)}"
-        if system is None:
+        if not isinstance(qoperator, Qobj):
+            prefactor = prefactor * qoperator
+            names = {}
+            if system is None:
+                graph = GraphDescriptor("Empty graph", {}, {}, {})
+                model = qutip_model_from_dims({})
+                system = SystemDescriptor(graph, model, sites={})
+            qoperator = qeye(1)
+        elif system is None:
             dims = qoperator.dims[0]
             model = qutip_model_from_dims(dims)
             if names is None:
@@ -73,15 +78,19 @@ class QutipOperator(Operator):
                 {},
             )
             system = SystemDescriptor(graph, model, sites=sites)
-        if names is None:
-            names = {s: i for i, s in enumerate(system.sites)}
+        else:
+            # If qoperator is nontrivial, ensure that names points to each factor of qoperator.
+            dims = qoperator.dims[0]
+            if names is None:
+                names = {s: i for i, s in enumerate(system.sites)}
+            elif len(names) != len(dims):
+                raise ValueError(
+                    f"dimensions {qoperator.dims[0]} and name dictionary {names} do not match."
+                )
+            elif any(pos >= len(dims) for pos in names.values()):
+                raise ValueError(f"names {names} points out of dims {dims}")
 
         self.system = system
-        assert len(qoperator.dims[0]) == len(
-            names
-        ), f"{qoperator.dims[0]} and {names} have different lengths"
-        assert all(pos < len(names) for pos in names.values())
-
         self.operator = qoperator
         self.site_names = names
         self.prefactor = prefactor
@@ -387,7 +396,11 @@ class QutipOperator(Operator):
                 {site: next_index + i for i, site in enumerate(out_sites)}
             )
             extra_identities = (sites[site]["identity"] for site in out_sites)
-            operator_qutip = tensor(operator_qutip, *extra_identities)
+            operator_qutip = (
+                tensor(operator_qutip, *extra_identities)
+                if site_names
+                else tensor(*extra_identities)
+            )
 
         # Add sites which are in site_names, but not in block
         block = block + tuple((site for site in site_names if site not in block))
@@ -400,13 +413,13 @@ class QutipOperator(Operator):
         return operator_qutip.permute(shuffle)
 
     def tr(self):
-        """ """
+        """Compute the trace"""
         prefactor = self.prefactor
         if prefactor == 0:
             return prefactor
 
         site_names: Dict[str, int] = self.site_names
-        op_tr = self.operator.tr() if site_names else 0.0
+        op_tr = self.operator.tr() if site_names else 1.0
         if op_tr == 0.0:
             return op_tr
 
@@ -415,8 +428,6 @@ class QutipOperator(Operator):
         if len(site_names) < len(dimensions):
             names = set(site_names)
             dims_other = (dim for site, dim in dimensions.items() if site not in names)
-            prefactor = reduce(lambda x, y: x * y, dims_other, self.prefactor)
-        else:
-            prefactor = self.prefactor
+            prefactor = reduce(lambda x, y: x * y, dims_other, prefactor)
         result = op_tr * prefactor
         return result

--- a/alpsqutip/operators/register_ops.py
+++ b/alpsqutip/operators/register_ops.py
@@ -1767,9 +1767,19 @@ def mul_qutip_operator_qutip_operator(x_op: QutipOperator, y_op: QutipOperator):
     -------
 
     """
-    system = x_op.system.union(y_op.system)
+
     x_names = x_op.site_names
     y_names = y_op.site_names
+    if not x_names:
+        if not y_names:
+            system = x_op.system.union(y_op.system)
+            prefactor = x_op.prefactor * y_op.prefactor
+            return QutipOperator(1, names=x_names, prefactor=prefactor, system=system)
+        return y_op * x_op.prefactor
+    if not y_names:
+        return x_op * y_op.prefactor
+
+    system = x_op.system.union(y_op.system)
     if x_names == y_names:
         return QutipOperator(
             x_op.operator * y_op.operator,

--- a/test/test_qutip.py
+++ b/test/test_qutip.py
@@ -591,3 +591,17 @@ def test_reduce_to_proper_spaces():
     assert check_equality(
         spectrum, np.array([0, 0.25, 0.375, 0.375])
     ), f"{reduced_state.eigenenergies()}"
+
+
+def test_trivial_QutipOperator():
+    b = QutipOperator(sigmax(), prefactor=0.5)
+    system = b.system
+    a = QutipOperator(1, prefactor=2, system=system)
+    ab = a * b
+    print("a:", a)
+    print("b:", b)
+    print("ab:", ab)
+    check_equality(ab, 2 * b)
+    check_equality(a.tr(), 4.0)
+    check_equality((a * a).tr(), 8.0)
+    check_equality((b * b).tr(), 0.5)


### PR DESCRIPTION
Sometimes, the result of an operation requires generating a QutipOperator from a scalar value. This PR handles that case by setting internally the operator to  `qeye(1)` and the scalar in the place of the prefactor.